### PR TITLE
Add remote link support

### DIFF
--- a/s3pd/__init__.py
+++ b/s3pd/__init__.py
@@ -111,6 +111,11 @@ def resolve_link(bucket, key, signed, depth=10):
     client = create_client(signed)
     filesize = get_filesize(client, bucket, key)
 
+    # There is no need to resolve files with a size >1KB, these could
+    # realistically be links
+    if filesize > 1024:
+        return bucket, key
+
     link_sentinel = '#S3PDLINK#'
     with BytesIO() as stream:
         client.download_fileobj(Bucket=bucket, Key=key, Fileobj=stream)

--- a/s3pd/__init__.py
+++ b/s3pd/__init__.py
@@ -10,7 +10,7 @@ import botocore
 import boto3
 
 
-LINK_SENTINEL = '#S3PDLINK#'
+LINK_SENTINEL = '#S3LINK#'
 
 @contextlib.contextmanager
 def shm_file(size, destination):

--- a/s3pd/__init__.py
+++ b/s3pd/__init__.py
@@ -9,6 +9,9 @@ from io import BytesIO
 import botocore
 import boto3
 
+
+LINK_SENTINEL = '#S3PDLINK#'
+
 @contextlib.contextmanager
 def shm_file(size, destination):
     """Create a named shared memory and return its file object.
@@ -115,16 +118,15 @@ def resolve_link(bucket, key, client, depth=10):
     if filesize > 1024:
         return bucket, key
 
-    link_sentinel = '#S3PDLINK#'
     with BytesIO() as stream:
         client.download_fileobj(Bucket=bucket, Key=key, Fileobj=stream)
         content = stream.getvalue().decode('utf-8').strip()
 
     # Check whether this file is a link
-    if not content.startswith(link_sentinel):
+    if not content.startswith(LINK_SENTINEL):
         return bucket, key
 
-    url = content[len(link_sentinel):]
+    url = content[len(LINK_SENTINEL):]
     parsed_url = urlparse(url)
     path = parsed_url.path
 

--- a/s3pd/__init__.py
+++ b/s3pd/__init__.py
@@ -111,7 +111,7 @@ def resolve_link(bucket, key, signed, depth=10):
     client = create_client(signed)
     filesize = get_filesize(client, bucket, key)
 
-    # There is no need to resolve files with a size >1KB, these could
+    # There is no need to resolve files with a size >1KB, these could not
     # realistically be links
     if filesize > 1024:
         return bucket, key
@@ -134,7 +134,6 @@ def resolve_link(bucket, key, signed, depth=10):
                 key=key,
                 signed=signed,
                 depth=depth-1)
-        # If not, return the key
         return bucket, key
 
 def s3pd(url, processes=8, chunksize=67108864, destination=None, func=None,


### PR DESCRIPTION
This adds the capability for s3pd to handle links.

Under the following conditions, link resolution will be performed:
- The file size is <1KB
- The file content starts with `#S3PDLINK#`

If these conditions are met, then the rest of the file is considered to be an url to an other file.

Notes:
- Support for multiple levels of links is handled. The limit is hard-coded at 10 indirections and cannot be changed through the API.
- Support for relative link buckets is handled. In case the url is a simple key, then the current bucket is assumed.
- There is no support for varying signed/unsigned access while resolving links. Either all the access are signed, or unsigned.

Tests were performed with success the following files/scenarios:
```
absolute_absolute_link.txt:
#S3PDLINK#s3://avallee-bucket/users/avallee/absolute_link.txt

absolute_link.txt:
#S3PDLINK#s3://avallee-bucket/users/avallee/content.txt

absolute_relative_link.txt:
#S3PDLINK#s3://avallee-bucket/users/avallee/relative_link.txt

content.txt:
123

cyclical_link.txt:
#S3PDLINK#users/avallee/cyclical_link.txt

relative_absolute_link.txt:
#S3PDLINK#users/avallee/absolute_link.txt

relative_link.txt:
#S3PDLINK#users/avallee/content.txt

relative_relative_link.txt:
#S3PDLINK#users/avallee/relative_link.txt

```