### PR TITLE
ensure shmfile is close in case destination is specified

### DIFF
--- a/s3pd/__init__.py
+++ b/s3pd/__init__.py
@@ -22,10 +22,10 @@ def shm_file(size, destination):
     :return: A tuple `(file object, path)` to be used from a context manager.
     """
     if destination:
-        shmfile = open(destination, 'w+b')
-        os.truncate(shmfile.fileno(), size)
-        shmfile.seek(0)
-        yield shmfile, destination
+        with open(destination, 'w+b') as shmfile:
+            os.truncate(shmfile.fileno(), size)
+            shmfile.seek(0)
+            yield shmfile, destination
     else:
         with NamedTemporaryFile(mode='wb', prefix='s3-', dir='/dev/shm') as shmfile:
             os.truncate(shmfile.fileno(), size)


### PR DESCRIPTION
To avoid `ResourceWarning` caught by `pytest`:

```
>               warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
E               pytest.PytestUnraisableExceptionWarning: Exception ignored in: <_io.FileIO [closed]>
E               
E               Traceback (most recent call last):
E                 File "/home/kyeung/git/FRONT/analytics-client/venv/lib/python3.8/site-packages/xxxx/xxxx.py", line 107, in open
E                   s3pd(url=s3path, destination=self._local_tmpfile.name, signed=True,
E               ResourceWarning: unclosed file <_io.BufferedRandom name='/dev/shm/xxxx-kl_y66ti-2016-07-01.h5'>

```