### PR TITLE
don't fork more children than count of chunks

### DIFF
--- a/s3pd/__init__.py
+++ b/s3pd/__init__.py
@@ -206,6 +206,9 @@ def s3pd(
     filesize = get_filesize(client, bucket, key, version=version)
     chunks = create_chunks(chunksize, filesize)
 
+    # Don't fork more children than chunks
+    processes = min(processes, len(chunks))
+
     # Prevent multiprocessing children to fork
     if current_process().daemon:
         processes = 1


### PR DESCRIPTION
This is to reduce children if there are fewer chunks. There is no need to fork for 1 chunk.